### PR TITLE
refactor(database): export pool singleton

### DIFF
--- a/src/config/database.js
+++ b/src/config/database.js
@@ -2,6 +2,4 @@
 
 const { Pool } = require('pg');
 
-module.exports = () => {
-  return new Pool({ connectionString: process.env.DATABASE_URL });
-};
+module.exports = new Pool({ connectionString: process.env.DATABASE_URL });

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,9 +1,7 @@
 'use strict';
 
 module.exports = app => {
-  const pool = require('./database')();
-
-  require('./passport')(pool);
+  require('./passport')();
   require('./express')(app);
-  require('./routes')(app, pool);
+  require('./routes')(app);
 };

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -2,13 +2,10 @@
 
 const LocalStrategy = require('passport-local').Strategy;
 const passport = require('passport');
-const Password = require('../services/password');
-const Users = require('../services/users');
+const password = require('../services/password');
+const users = require('../services/users');
 
-module.exports = (pool) => {
-  const password = new Password(pool);
-  const users = new Users(pool);
-
+module.exports = () => {
   passport.use(
     new LocalStrategy(function(username, passwd, done) {
       (async () => {

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -2,16 +2,13 @@
 
 const express = require('express');
 const path = require('path');
-const AuthenticationService = require('../services/authentication');
 
-module.exports = (app, pool) => {
-  const auth = new AuthenticationService();
-
+module.exports = app => {
   app.use('/', express.static(path.join(__dirname, '/../../dist')));
 
-  require('../routes/athentication')(app, auth);
-  require('../routes/car-classes')(app, auth, pool);
-  require('../routes/car-shows')(app, auth, pool);
-  require('../routes/votes')(app, auth, pool);
-  require('../routes/users')(app, auth, pool);
+  require('../routes/athentication')(app);
+  require('../routes/car-classes')(app);
+  require('../routes/car-shows')(app);
+  require('../routes/users')(app);
+  require('../routes/votes')(app);
 };

--- a/src/routes/athentication.js
+++ b/src/routes/athentication.js
@@ -1,6 +1,8 @@
 'use strict';
 
-module.exports = (app, auth) => {
+const auth = require('../services/authentication');
+
+module.exports = (app) => {
   app.post('/login', auth.authenticate.bind(auth));
 
   app.post('/logout', (req, res) => {

--- a/src/routes/car-classes.js
+++ b/src/routes/car-classes.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const Repository = require('./repository');
-const CarClassesService = require('../services/car-classes');
+const carClasses = require('../services/car-classes');
 
-module.exports = (app, auth, pool) => {
-  const repository = new Repository(new CarClassesService(pool));
+module.exports = app => {
+  const repository = new Repository(carClasses);
 
   app.get('/car-classes', (req, res) => {
     repository.getAll(req, res);

--- a/src/routes/car-shows.js
+++ b/src/routes/car-shows.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const Repository = require('./repository');
-const CarShowsService = require('../services/car-shows');
+const carShows = require('../services/car-shows');
 
-module.exports = (app, auth, pool) => {
-  const carShowService = new CarShowsService(pool);
-  const repository = new Repository(carShowService);
+module.exports = (app) => {
+  const repository = new Repository(carShows);
   const route = '/car-shows';
 
   app.get(`${route}`, (req, res) => {
@@ -14,7 +13,7 @@ module.exports = (app, auth, pool) => {
 
   app.get(`${route}/current`, async (req, res) => {
     try {
-      const data = await carShowService.getCurrent();
+      const data = await carShows.getCurrent();
       res.send(data);
     } catch (e) {
       console.error(e.stack);

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const PasswordService = require('../services/password');
+const auth = require('../services/authentication');
+const password = require('../services/password');
 const Repository = require('./repository');
-const UsersService = require('../services/users');
+const users = require('../services/users');
 
-module.exports = (app, auth, pool) => {
-  const password = new PasswordService(pool);
-  const users = new UsersService(pool);
+module.exports = app => {
   const userRepo = new Repository(users);
 
   app.get(
@@ -76,6 +75,7 @@ module.exports = (app, auth, pool) => {
           );
           res.send({ success: true });
         } catch (err) {
+          console.log('we are in the catch');
           const msg = err.toString();
           if (/Error: Invalid/.test(msg)) {
             res.status(400).send({ reason: msg });

--- a/src/routes/votes.js
+++ b/src/routes/votes.js
@@ -1,29 +1,12 @@
 'use strict';
 
 const Repository = require('./repository');
-const VotesService = require('../services/votes');
+const votes = require('../services/votes');
 
-module.exports = (app, auth, pool) => {
-  const votes = new VotesService(pool);
+module.exports = (app) => {
   const repository = new Repository(votes);
 
   app.get('/votes', (req, res) => {
     repository.getAll(req, res);
   });
-
-  // app.get('/teas/:id', (req, res) => {
-  //   repository.get(req, res);
-  // });
-
-  // app.post('/teas/:id', auth.requireApiLogin.bind(auth), (req, res) => {
-  //   repository.update(req, res);
-  // });
-
-  // app.post('/teas', auth.requireApiLogin.bind(auth), (req, res) => {
-  //   repository.insert(req, res);
-  // });
-
-  // app.delete('/teas/:id', auth.requireApiLogin.bind(auth), (req, res) => {
-  //   repository.delete(req, res);
-  // });
 };

--- a/src/services/authentication.js
+++ b/src/services/authentication.js
@@ -3,7 +3,7 @@
 const jwt = require('jsonwebtoken');
 const passport = require('passport');
 
-module.exports = class AuthenticationService {
+class Authentication {
   authenticate(req, res, next) {
     const auth = passport.authenticate('local', (err, user) => {
       if (err) {
@@ -66,7 +66,10 @@ module.exports = class AuthenticationService {
   requireRoleOrId(role) {
     return (req, res, next) => {
       const user = this.verifyToken(req);
-      if (user.id.toString() === req.params.id || user.roles.find(r => r === role)) {
+      if (
+        user.id.toString() === req.params.id ||
+        user.roles.find(r => r === role)
+      ) {
         next();
       } else {
         res.status(403);
@@ -110,4 +113,6 @@ module.exports = class AuthenticationService {
       token: token
     });
   }
-};
+}
+
+module.exports = new Authentication();

--- a/src/services/car-classes.js
+++ b/src/services/car-classes.js
@@ -1,14 +1,14 @@
 'use strict';
 
-module.exports = class CarClasses {
-  constructor(pool) {
-    this._pool = pool;
-  }
+const pool = require('../config/database');
 
+class CarClasses {
   async getAll() {
-    const client = await this._pool.connect();
+    const client = await pool.connect();
     const qres = await client.query('select * from car_classes');
     client.release();
     return qres.rows;
   }
 };
+
+module.exports = new CarClasses();

--- a/src/services/car-shows.js
+++ b/src/services/car-shows.js
@@ -1,10 +1,8 @@
-module.exports = class CarShows {
-  constructor(pool) {
-    this._pool = pool;
-  }
+const pool = require('../config/database');
 
+class CarShows {
   async getAll() {
-    const client = await this._pool.connect();
+    const client = await pool.connect();
     const qres = await Promise.all([
       client.query('select * from car_shows order by year desc'),
       client.query('select * from car_show_classes')
@@ -14,7 +12,7 @@ module.exports = class CarShows {
   }
 
   async get(id) {
-    const client = await this._pool.connect();
+    const client = await pool.connect();
     const qres = await Promise.all([
       client.query('select * from car_shows where id = $1', [id]),
       client.query('select * from car_show_classes where car_show_rid = $1', [
@@ -27,7 +25,7 @@ module.exports = class CarShows {
 
   async getCurrent() {
     let classesRes;
-    const client = await this._pool.connect();
+    const client = await pool.connect();
     const year = new Date().getFullYear();
     const showsRes = await client.query(
       'select * from car_shows where year = $1',
@@ -45,7 +43,7 @@ module.exports = class CarShows {
 
   async save(show) {
     let id = show.id;
-    const client = await this._pool.connect();
+    const client = await pool.connect();
     if (id) {
       await client.query(
         'update car_shows set name = $1, date = $2, year = $3 where id = $4',
@@ -101,3 +99,5 @@ function merge(shows, classes) {
     })
   }));
 }
+
+module.exports = new CarShows();

--- a/src/services/encryption.js
+++ b/src/services/encryption.js
@@ -2,7 +2,7 @@
 
 const crypto = require('crypto');
 
-module.exports = class EncryptionService {
+class EncryptionService {
   salt() {
     return crypto.randomBytes(128).toString('base64');
   }
@@ -12,3 +12,5 @@ module.exports = class EncryptionService {
     return hmac.update(password).digest('hex');
   }
 };
+
+module.exports = new EncryptionService();

--- a/src/services/password.js
+++ b/src/services/password.js
@@ -1,13 +1,9 @@
 'use strict';
 
-const Encryption = require('./encryption');
+const encryption = require('./encryption');
+const pool = require('../config/database');
 
-module.exports = class Password {
-  constructor(pool) {
-    this._pool = pool;
-    this._encryption = new Encryption();
-  }
-
+class Password {
   async initialize(id, password) {
     const reject =
       this._missingParam(id, 'id') || this._missingParam(password, 'password');
@@ -15,7 +11,7 @@ module.exports = class Password {
       return reject;
     }
 
-    const client = await this._pool.connect();
+    const client = await pool.connect();
     const data = await this._getCredentials(client, id);
     if (data) {
       return Promise.reject(new Error('Password already initialized'));
@@ -33,7 +29,7 @@ module.exports = class Password {
       return reject;
     }
 
-    const client = await this._pool.connect();
+    const client = await pool.connect();
     if (!await this._passwordMatches(client, id, currentPassword)) {
       return Promise.reject(new Error('Invalid password'));
     }
@@ -44,7 +40,7 @@ module.exports = class Password {
   }
 
   async matches(id, password) {
-    const client = await this._pool.connect();
+    const client = await pool.connect();
     const m = this._passwordMatches(client, id, password);
     client.release();
     return m;
@@ -52,7 +48,7 @@ module.exports = class Password {
 
   async _passwordMatches(client, id, password) {
     const cred = await this._getCredentials(client, id);
-    return !!(cred && cred.password === this._encryption.hash(cred.salt, password));
+    return !!(cred && cred.password === encryption.hash(cred.salt, password));
   }
 
   async _getCredentials(client, id) {
@@ -70,8 +66,8 @@ module.exports = class Password {
   }
 
   _updateCredentials(client, id, password) {
-    const salt = this._encryption.salt();
-    const hash = this._encryption.hash(salt, password);
+    const salt = encryption.salt();
+    const hash = encryption.hash(salt, password);
 
     return client.query(
       `insert into user_credentials (user_rid, password, salt)
@@ -82,3 +78,5 @@ module.exports = class Password {
     );
   }
 };
+
+module.exports = new Password();

--- a/src/services/votes.js
+++ b/src/services/votes.js
@@ -1,12 +1,10 @@
 'use strict';
 
-module.exports = class Votes {
-  constructor(pool) {
-    this._pool = pool;
-  }
+const database = require('../config/database');
 
+class Votes {
   async getAll(year) {
-    const client = await this._pool.connect();
+    const client = await database.connect();
     const qres = await (year
       ? client.query('select * from votes where year = $1', [year])
       : client.query('select * from votes'));
@@ -15,7 +13,7 @@ module.exports = class Votes {
   }
 
   // async get(id) {
-  //   const client = await this._pool.connect();
+  //   const client = await pool.connect();
   //   const qres = await client.query(
   //     `select ${columns} from ${tables} where teas.id = $1`,
   //     [id]
@@ -26,7 +24,7 @@ module.exports = class Votes {
 
   // async save(tea) {
   //   let id = tea.id;
-  //   const client = await this._pool.connect();
+  //   const client = await pool.connect();
   //   if (id) {
   //     await client.query(
   //       `update teas set name = $1, tea_category_rid = $2, description = $3, instructions = $4, rating = $5, url = $6, price = $7 where id = $8`,
@@ -65,7 +63,7 @@ module.exports = class Votes {
   // }
 
   // async delete(id) {
-  //   const client = await this._pool.connect();
+  //   const client = await pool.connect();
   //   await client.query(`delete from tea_purchase_links where tea_rid = $1`, [
   //     id
   //   ]);
@@ -74,3 +72,5 @@ module.exports = class Votes {
   //   return {};
   // }
 };
+
+module.exports = new Votes();

--- a/test/config/passport.spec.js
+++ b/test/config/passport.spec.js
@@ -2,7 +2,10 @@
 
 const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
-const MockPool = require('../mocks/mock-pool');
+const sinon = require('sinon');
+
+const password = require('../../src/services/password');
+const users = require('../../src/services/users');
 
 class MockLocalStrategy {
   constructor(cb) {
@@ -20,54 +23,30 @@ class MockPassport {
   }
 }
 
-let passwordMatches = false;
-let matchesCalls;
-let matchesId;
-let matchesPassword;
-class MockPassword {
-  matches(id, password) {
-    matchesCalls++;
-    matchesId = id;
-    matchesPassword = password;
-    return Promise.resolve(passwordMatches);
-  }
-}
-
-let returnedUser;
-let getCalls;
-let getCallArgs;
-let userGetPromise = Promise.resolve();
-class MockUsers {
-  get(u) {
-    getCalls++;
-    getCallArgs = u;
-    return userGetPromise;
-  }
-}
-
 describe('config: passport', () => {
   let passport;
 
   beforeEach(() => {
-    const pool = new MockPool();
     passport = new MockPassport();
-    getCalls = 0;
-    getCallArgs = undefined;
-    matchesCalls = 0;
     const config = proxyquire('../../src/config/passport', {
       passport: passport,
-      'passport-local': { Strategy: MockLocalStrategy },
-      '../services/password': MockPassword,
-      '../services/users': MockUsers
+      'passport-local': { Strategy: MockLocalStrategy }
     });
-    config(pool);
+    sinon.stub(users, 'get').resolves();
+    sinon.stub(password, 'matches').resolves(false);
+    config();
+  });
+
+  afterEach(() => {
+    users.get.restore();
+    password.matches.restore();
   });
 
   describe('authentication', () => {
     it('gets the user', () => {
       passport.strategy.authenticate('kws@email.com', 'secretSauc3', () => {});
-      expect(getCalls).to.equal(1);
-      expect(getCallArgs).to.equal('kws@email.com');
+      expect(users.get.calledOnce).to.be.true;
+      expect(users.get.calledWith('kws@email.com')).to.be.true;
     });
 
     describe('without a matching user', () => {
@@ -77,7 +56,7 @@ describe('config: passport', () => {
           'secretSauc3',
           () => {}
         );
-        expect(matchesCalls).to.equal(0);
+        expect(password.matches.called).to.be.false;
       });
 
       it('calls the done callback with false', done => {
@@ -94,13 +73,14 @@ describe('config: passport', () => {
     });
 
     describe('with a matching user', () => {
+      let returnedUser;
       beforeEach(() => {
         returnedUser = {
           id: 1138,
           firstName: 'Karl',
           lastName: 'Smith'
         };
-        userGetPromise = Promise.resolve(returnedUser);
+        users.get.resolves({ ...returnedUser });
       });
 
       it('checks the password', async () => {
@@ -109,13 +89,13 @@ describe('config: passport', () => {
           'secretSauc3',
           () => {}
         );
-        await userGetPromise;
-        expect(matchesCalls).to.equal(1);
-        expect(matchesId).to.equal(1138);
-        expect(matchesPassword).to.equal('secretSauc3');
+        await users.get();
+        expect(password.matches.calledOnce).to.be.true;
+        expect(password.matches.calledWith(1138, 'secretSauc3')).to.be.true;
       });
 
       it('calls done with false if the password does not match', done => {
+        password.matches.resolves(false);
         passport.strategy.authenticate(
           'kws@email.com',
           'secretSauc3',
@@ -128,7 +108,7 @@ describe('config: passport', () => {
       });
 
       it('calls done with uesr if the password does match', done => {
-        passwordMatches = true;
+        password.matches.resolves(true);
         passport.strategy.authenticate(
           'kws@email.com',
           'secretSauc3',

--- a/test/routes/users.spec.js
+++ b/test/routes/users.spec.js
@@ -236,12 +236,14 @@ describe('route: /users', () => {
           })
           .end((err, res) => {
             expect(users.save.calledOnce).to.be.true;
-            expect(users.save.calledWith({
-              id: 30,
-              firstName: 'Barney',
-              lastName: 'Rubble',
-              email: 'barney@rubble.kings.io'
-            })).to.be.true;
+            expect(
+              users.save.calledWith({
+                id: 30,
+                firstName: 'Barney',
+                lastName: 'Rubble',
+                email: 'barney@rubble.kings.io'
+              })
+            ).to.be.true;
             done();
           });
       });
@@ -265,12 +267,14 @@ describe('route: /users', () => {
           })
           .end((err, res) => {
             expect(users.save.calledOnce).to.be.true;
-            expect(users.save.calledWith({
-              id: 30,
-              firstName: 'Barney',
-              lastName: 'Rubble',
-              email: 'barney@rubble.kings.io'
-            })).to.be.true;
+            expect(
+              users.save.calledWith({
+                id: 30,
+                firstName: 'Barney',
+                lastName: 'Rubble',
+                email: 'barney@rubble.kings.io'
+              })
+            ).to.be.true;
             done();
           });
       });
@@ -313,12 +317,14 @@ describe('route: /users', () => {
           })
           .end((err, res) => {
             expect(users.save.calledOnce).to.be.true;
-            expect(users.save.calledWith({
-              id: 30,
-              firstName: 'Barney',
-              lastName: 'Rubble',
-              email: 'barney@rubble.kings.io'
-            }));
+            expect(
+              users.save.calledWith({
+                id: 30,
+                firstName: 'Barney',
+                lastName: 'Rubble',
+                email: 'barney@rubble.kings.io'
+              })
+            );
             done();
           });
       });
@@ -391,11 +397,13 @@ describe('route: /users', () => {
           })
           .end((err, res) => {
             expect(users.save.calledOnce).to.be.true;
-            expect(users.save.calledWith({
-              firstName: 'Barney',
-              lastName: 'Rubble',
-              email: 'barney@rubble.kings.io'
-            }));
+            expect(
+              users.save.calledWith({
+                firstName: 'Barney',
+                lastName: 'Rubble',
+                email: 'barney@rubble.kings.io'
+              })
+            );
             done();
           });
       });
@@ -437,11 +445,13 @@ describe('route: /users', () => {
           })
           .end((err, res) => {
             expect(users.save.calledOnce).to.be.true;
-            expect(users.save.calledWith({
-              firstName: 'Barney',
-              lastName: 'Rubble',
-              email: 'barney@rubble.kings.io'
-            }));
+            expect(
+              users.save.calledWith({
+                firstName: 'Barney',
+                lastName: 'Rubble',
+                email: 'barney@rubble.kings.io'
+              })
+            );
             done();
           });
       });
@@ -478,8 +488,7 @@ describe('route: /users', () => {
 
     afterEach(() => {
       password.change.restore();
-    })
-
+    });
 
     it('requires an API login', done => {
       auth.isAuthenticated.returns(false);
@@ -505,7 +514,13 @@ describe('route: /users', () => {
         })
         .end((err, res) => {
           expect(password.change.calledOnce).to.be.true;
-          expect(password.change.calledWith('30', 'IamNewPa$$worD', 'iAmCurr3ntPassw0rd')).to.be.true;
+          expect(
+            password.change.calledWith(
+              '30',
+              'IamNewPa$$worD',
+              'iAmCurr3ntPassw0rd'
+            )
+          ).to.be.true;
           done();
         });
     });

--- a/test/routes/users.spec.js
+++ b/test/routes/users.spec.js
@@ -53,21 +53,21 @@ describe('route: /users', () => {
       iat: 'whatever',
       exp: 19930124509912485
     });
-    sinon.stub(users, 'getAll').returns(Promise.resolve(testData));
+    sinon.stub(users, 'getAll').resolves(testData);
     sinon
       .stub(users, 'get')
       .withArgs(1138)
-      .returns(Promise.resolve({
+      .resolves({
         id: 1138,
         firstName: 'Teddy',
         lastName: 'Senspeck',
         roles: ['admin']
-      }));
-    users.get.withArgs('30').returns(Promise.resolve({
+      });
+    users.get.withArgs('30').resolves({
       id: 30,
       firstName: 'Barney',
       lastName: 'Rubble'
-    }));
+    });
     sinon.stub(users, 'save');
   });
 
@@ -276,12 +276,12 @@ describe('route: /users', () => {
       });
 
       it('returns the saved data', done => {
-        users.save.returns(Promise.resolve({
+        users.save.resolves({
           id: 30,
           firstName: 'Barney',
           lastName: 'Rubble',
           email: 'barney@rubble.kings.io'
-        }));
+        });
         request(app)
           .post('/users/30')
           .send({
@@ -401,12 +401,12 @@ describe('route: /users', () => {
       });
 
       it('returns the saved data', done => {
-        users.save.returns(Promise.resolve({
+        users.save.resolves({
           id: 314159,
           firstName: 'Barney',
           lastName: 'Rubble',
           email: 'barney@rubble.kings.io'
-        }));
+        });
         request(app)
           .post('/users')
           .send({

--- a/test/routes/votes.spec.js
+++ b/test/routes/votes.spec.js
@@ -70,7 +70,7 @@ describe('route: /votes', () => {
   afterEach(() => {
     auth.isAuthenticated.restore();
     votes.getAll.restore();
-  })
+  });
 
   describe('get', () => {
     registerGetTests();

--- a/test/routes/votes.spec.js
+++ b/test/routes/votes.spec.js
@@ -1,69 +1,20 @@
 'use strict';
 
+const auth = require('../../src/services/authentication');
 const expect = require('chai').expect;
 const express = require('express');
-const MockPool = require('../mocks/mock-pool');
-const proxyquire = require('proxyquire');
 const request = require('supertest');
+const votes = require('../../src/services/votes');
 const sinon = require('sinon');
 
 describe('route: /votes', () => {
-  let app;
-  let auth;
-  let mockJWT;
+  const app = express();
+  require('../../src/config/express')(app);
+  require('../../src/routes/votes')(app);
+
   let testData;
 
-  // let deleteCalled;
-  // let deleteCalledWith;
-  // let saveCalled;
-  // let saveCalledWith;
-  class MockVotesService {
-    getAll() {
-      return Promise.resolve(testData);
-    }
-
-    // get(id) {
-    //   const value = testData.find(item => item.id.toString() === id.toString());
-    //   return Promise.resolve(value);
-    // }
-
-    // save(tea) {
-    //   saveCalled++;
-    //   saveCalledWith = tea;
-
-    //   if (tea.id && !testData.find(item => item.id === tea.id)) {
-    //     return Promise.resolve();
-    //   }
-    //   const value = { ...{ id: 314159 }, ...tea };
-    //   return Promise.resolve(value);
-    // }
-
-    // delete(id) {
-    //   deleteCalled++;
-    //   deleteCalledWith = id;
-    //   return Promise.resolve({});
-    // }
-  }
-
   beforeEach(() => {
-    mockJWT = {};
-    const AuthService = proxyquire('../../src/services/authentication', {
-      jsonwebtoken: mockJWT
-    });
-    sinon.stub(mockJWT, 'verify');
-    mockJWT.verify.returns({
-      id: 1138,
-      firstName: 'Ted',
-      lastName: 'Senspeck',
-      roles: ['user'],
-      iat: 'whatever',
-      exp: 19930124509912485
-    });
-    auth = new AuthService();
-
-    app = express();
-    require('../../src/config/express')(app);
-    const pool = new MockPool();
     testData = [
       {
         id: 10,
@@ -112,17 +63,21 @@ describe('route: /votes', () => {
         rating: 4
       }
     ];
-    proxyquire('../../src/routes/votes', {
-      '../services/votes': MockVotesService
-    })(app, auth, pool);
+    sinon.stub(auth, 'isAuthenticated').returns(true);
+    sinon.stub(votes, 'getAll').returns(testData);
   });
+
+  afterEach(() => {
+    auth.isAuthenticated.restore();
+    votes.getAll.restore();
+  })
 
   describe('get', () => {
     registerGetTests();
 
     describe('when not logged in', () => {
       beforeEach(() => {
-        mockJWT.verify.throws(new Error('no loggy loggy'));
+        auth.isAuthenticated.returns(false);
       });
 
       registerGetTests();
@@ -139,170 +94,5 @@ describe('route: /votes', () => {
           done();
         });
     });
-
-    // describe('with an id', () => {
-    //   it('returns the data if the tea is found', done => {
-    //     request(app)
-    //       .get('/api/teas/30')
-    //       .end((err, res) => {
-    //         expect(res.status).to.equal(200);
-    //         expect(res.body).to.deep.equal({
-    //           id: 30,
-    //           name: 'Earl Grey',
-    //           teaCategoryId: 2,
-    //           teaCategoryName: 'Black',
-    //           description: 'flowery tea',
-    //           instructions: 'do something with the tea',
-    //           rating: 3
-    //         });
-    //         done();
-    //       });
-    //   });
-
-    //   it('returns 404 if the tea is not found', done => {
-    //     request(app)
-    //       .get('/api/teas/314159')
-    //       .end((err, res) => {
-    //         expect(res.status).to.equal(404);
-    //         done();
-    //       });
-    //   });
-    // });
   }
-
-  // describe('post', () => {
-  //   beforeEach(() => {
-  //     saveCalled = 0;
-  //     saveCalledWith = null;
-  //   });
-
-  //   describe('without an id', () => {
-  //     it('requires an API login', done => {
-  //       mockJWT.verify.throws(new Error('no loggy loggy'));
-  //       request(app)
-  //         .post('/api/teas')
-  //         .send({
-  //           name: 'Grassy Green',
-  //           teaCategoryId: 1,
-  //           teaCategoryName: 'Green',
-  //           description: 'something about the tea',
-  //           instructions: 'do something with the tea',
-  //           rating: 2
-  //         })
-  //         .end((err, res) => {
-  //           expect(saveCalled).to.equal(0);
-  //           expect(res.status).to.equal(401);
-  //           expect(res.body).to.deep.equal({});
-  //           done();
-  //         });
-  //     });
-
-  //     it('saves the new tea', done => {
-  //       request(app)
-  //         .post('/api/teas')
-  //         .send({
-  //           id: 420,
-  //           name: 'Grassy Green',
-  //           teaCategoryId: 1,
-  //           teaCategoryName: 'Green',
-  //           description: 'something about the tea',
-  //           instructions: 'do something with the tea',
-  //           rating: 2
-  //         })
-  //         .end((err, res) => {
-  //           expect(saveCalled).to.equal(1);
-  //           expect(saveCalledWith).to.deep.equal({
-  //             name: 'Grassy Green',
-  //             teaCategoryId: 1,
-  //             teaCategoryName: 'Green',
-  //             description: 'something about the tea',
-  //             instructions: 'do something with the tea',
-  //             rating: 2
-  //           });
-  //           done();
-  //         });
-  //     });
-  //   });
-
-  //   describe('with an id', () => {
-  //     it('requires an API login', done => {
-  //       mockJWT.verify.throws(new Error('no loggy loggy'));
-  //       request(app)
-  //         .post('/api/teas/30')
-  //         .send({
-  //           id: 30,
-  //           name: 'Grassy Green',
-  //           teaCategoryId: 1,
-  //           teaCategoryName: 'Green',
-  //           description: 'something about the tea',
-  //           instructions: 'do something with the tea',
-  //           rating: 2
-  //         })
-  //         .end((err, res) => {
-  //           expect(saveCalled).to.equal(0);
-  //           expect(res.status).to.equal(401);
-  //           expect(res.body).to.deep.equal({});
-  //           done();
-  //         });
-  //     });
-
-  //     it('calls the save', done => {
-  //       request(app)
-  //         .post('/api/teas/30')
-  //         .send({
-  //           id: 30,
-  //           name: 'Grassy Green',
-  //           teaCategoryId: 1,
-  //           teaCategoryName: 'Green',
-  //           description: 'something about the tea',
-  //           instructions: 'do something with the tea',
-  //           rating: 2
-  //         })
-  //         .end((err, res) => {
-  //           expect(saveCalled).to.equal(1);
-  //           expect(saveCalledWith).to.deep.equal({
-  //             id: 30,
-  //             name: 'Grassy Green',
-  //             teaCategoryId: 1,
-  //             teaCategoryName: 'Green',
-  //             description: 'something about the tea',
-  //             instructions: 'do something with the tea',
-  //             rating: 2
-  //           });
-  //           done();
-  //         });
-  //     });
-  //   });
-  // });
-
-  // describe('delete', () => {
-  //   beforeEach(() => {
-  //     deleteCalled = 0;
-  //     deleteCalledWith = null;
-  //   });
-
-  //   it('requires an API login', done => {
-  //     mockJWT.verify.throws(new Error('no loggy loggy'));
-  //     request(app)
-  //       .delete('/api/teas/30')
-  //       .send({})
-  //       .end((err, res) => {
-  //         expect(deleteCalled).to.equal(0);
-  //         expect(res.status).to.equal(401);
-  //         expect(res.body).to.deep.equal({});
-  //         done();
-  //       });
-  //   });
-
-  //   it('calls the delete', done => {
-  //     request(app)
-  //       .delete('/api/teas/30')
-  //       .send({})
-  //       .end((err, res) => {
-  //         expect(deleteCalled).to.equal(1);
-  //         expect(deleteCalledWith).to.equal(30);
-  //         done();
-  //       });
-  //   });
-  // });
 });

--- a/test/services/authentication.spec.js
+++ b/test/services/authentication.spec.js
@@ -45,11 +45,10 @@ describe('service: authentication', () => {
 
     beforeEach(() => {
       mockPassport = new MockPassport();
-      const Service = proxyquire('../../src/services/authentication', {
+      service = proxyquire('../../src/services/authentication', {
         passport: mockPassport,
         jsonwebtoken: mockJWT
       });
-      service = new Service();
     });
 
     it('calls passport authenticate', () => {
@@ -183,10 +182,9 @@ describe('service: authentication', () => {
   describe('refresh', () => {
     let service;
     beforeEach(() => {
-      const Service = proxyquire('../../src/services/authentication', {
+      service = proxyquire('../../src/services/authentication', {
         jsonwebtoken: mockJWT
       });
-      service = new Service();
 
       mockRequest.headers = {
         authorization: 'bearer thisisarandomtokenvalue'
@@ -285,10 +283,9 @@ describe('service: authentication', () => {
   describe('isAuthenticated', () => {
     let service;
     beforeEach(() => {
-      const Service = proxyquire('../../src/services/authentication', {
+      service = proxyquire('../../src/services/authentication', {
         jsonwebtoken: mockJWT
       });
-      service = new Service();
 
       mockRequest.headers = {
         authorization: 'bearer thisisarandomtokenvalue'
@@ -331,10 +328,9 @@ describe('service: authentication', () => {
     let service;
     let mockNext;
     beforeEach(() => {
-      const Service = proxyquire('../../src/services/authentication', {
+      service = proxyquire('../../src/services/authentication', {
         jsonwebtoken: mockJWT
       });
-      service = new Service();
 
       mockRequest.headers = {
         authorization: 'bearer thisisarandomtokenvalue'
@@ -377,10 +373,9 @@ describe('service: authentication', () => {
     let service;
     let mockNext;
     beforeEach(() => {
-      const Service = proxyquire('../../src/services/authentication', {
+      service = proxyquire('../../src/services/authentication', {
         jsonwebtoken: mockJWT
       });
-      service = new Service();
 
       mockRequest.headers = {
         authorization: 'bearer thisisarandomtokenvalue'
@@ -422,10 +417,9 @@ describe('service: authentication', () => {
     let service;
     let mockNext;
     beforeEach(() => {
-      const Service = proxyquire('../../src/services/authentication', {
+      service = proxyquire('../../src/services/authentication', {
         jsonwebtoken: mockJWT
       });
-      service = new Service();
 
       mockRequest.headers = {
         authorization: 'bearer thisisarandomtokenvalue'

--- a/test/services/car-classes.spec.js
+++ b/test/services/car-classes.spec.js
@@ -1,17 +1,16 @@
 'use strict';
 
 const expect = require('chai').expect;
-const MockPool = require('../mocks/mock-pool');
+const MockClient = require('../mocks/mock-client');
+const database = require('../../src/config/database');
 const sinon = require('sinon');
-const Service = require('../../src/services/car-classes');
+const service = require('../../src/services/car-classes');
 
 describe('service: car-classes', () => {
-  let pool;
-  let service;
+  let client;
   let testData;
 
   beforeEach(() => {
-    pool = new MockPool();
     testData = [
       {
         id: 1,
@@ -32,35 +31,39 @@ describe('service: car-classes', () => {
         active: true
       }
     ];
-    service = new Service(pool);
+    client = new MockClient();
+    sinon.stub(database, 'connect');
+    database.connect.returns(Promise.resolve(client));
+  });
+
+  afterEach(() => {
+    database.connect.restore();
   });
 
   describe('getAll', () => {
     it('connects to the pool', () => {
-      sinon.spy(pool, 'connect');
       service.getAll();
-      expect(pool.connect.calledOnce).to.be.true;
+      expect(database.connect.calledOnce).to.be.true;
     });
 
     it('queries the car classes', async () => {
-      sinon.spy(pool.test_client, 'query');
+      sinon.spy(client, 'query');
       await service.getAll();
-      expect(pool.test_client.query.calledOnce).to.be.true;
-      expect(pool.test_client.query.calledWith('select * from car_classes'))
-        .to.be.true;
+      expect(client.query.calledOnce).to.be.true;
+      expect(client.query.calledWith('select * from car_classes')).to.be.true;
     });
 
     it('returns the data', async () => {
-      sinon.stub(pool.test_client, 'query');
-      pool.test_client.query.returns(Promise.resolve({ rows: testData }));
+      sinon.stub(client, 'query');
+      client.query.returns(Promise.resolve({ rows: testData }));
       const data = await service.getAll();
       expect(data).to.deep.equal(testData);
     });
 
     it('releases the client', async () => {
-      sinon.spy(pool.test_client, 'release');
+      sinon.spy(client, 'release');
       await service.getAll();
-      expect(pool.test_client.release.calledOnce).to.be.true;
+      expect(client.release.calledOnce).to.be.true;
     });
   });
 });

--- a/test/services/car-classes.spec.js
+++ b/test/services/car-classes.spec.js
@@ -33,7 +33,7 @@ describe('service: car-classes', () => {
     ];
     client = new MockClient();
     sinon.stub(database, 'connect');
-    database.connect.returns(Promise.resolve(client));
+    database.connect.resolves(client);
   });
 
   afterEach(() => {
@@ -55,7 +55,7 @@ describe('service: car-classes', () => {
 
     it('returns the data', async () => {
       sinon.stub(client, 'query');
-      client.query.returns(Promise.resolve({ rows: testData }));
+      client.query.resolves({ rows: testData });
       const data = await service.getAll();
       expect(data).to.deep.equal(testData);
     });

--- a/test/services/car-shows.spec.js
+++ b/test/services/car-shows.spec.js
@@ -13,7 +13,7 @@ describe('service: car-classes', () => {
   beforeEach(() => {
     client = new MockClient();
     sinon.stub(pool, 'connect');
-    pool.connect.returns(Promise.resolve(client));
+    pool.connect.resolves(client);
     sinon.stub(client, 'query');
     client.query.returns({ rows: [] });
     testData = {
@@ -174,22 +174,15 @@ describe('service: car-classes', () => {
       await service.getAll();
       expect(client.query.calledTwice).to.be.true;
       expect(
-        client.query.calledWith(
-          'select * from car_shows order by year desc'
-        )
+        client.query.calledWith('select * from car_shows order by year desc')
       ).to.be.true;
-      expect(
-        client.query.calledWith('select * from car_show_classes')
-      ).to.be.true;
+      expect(client.query.calledWith('select * from car_show_classes')).to.be
+        .true;
     });
 
     it('returns the data', async () => {
-      client.query
-        .onCall(0)
-        .returns(Promise.resolve({ rows: testData.carShows }));
-      client.query
-        .onCall(1)
-        .returns(Promise.resolve({ rows: testData.carShowClasses }));
+      client.query.onCall(0).resolves({ rows: testData.carShows });
+      client.query.onCall(1).resolves({ rows: testData.carShowClasses });
       const data = await service.getAll();
       expect(data).to.deep.equal([
         {
@@ -340,10 +333,7 @@ describe('service: car-classes', () => {
       await service.get(3);
       expect(client.query.calledTwice).to.be.true;
       expect(
-        client.query.calledWith(
-          'select * from car_shows where id = $1',
-          [3]
-        )
+        client.query.calledWith('select * from car_shows where id = $1', [3])
       ).to.be.true;
       expect(
         client.query.calledWith(
@@ -359,14 +349,10 @@ describe('service: car-classes', () => {
     });
 
     it('returns the data for the car show', async () => {
-      client.query
-        .onCall(0)
-        .returns(Promise.resolve({ rows: [testData.carShows[2]] }));
-      client.query.onCall(1).returns(
-        Promise.resolve({
-          rows: testData.carShowClasses.filter(cls => cls.car_show_rid === 3)
-        })
-      );
+      client.query.onCall(0).resolves({ rows: [testData.carShows[2]] });
+      client.query.onCall(1).resolves({
+        rows: testData.carShowClasses.filter(cls => cls.car_show_rid === 3)
+      });
       const data = await service.get(3);
       expect(data).to.deep.equal({
         id: 3,
@@ -403,9 +389,7 @@ describe('service: car-classes', () => {
     });
 
     it('returns the data for a car show without classes', async () => {
-      client.query
-        .onCall(0)
-        .returns(Promise.resolve({ rows: [testData.carShows[2]] }));
+      client.query.onCall(0).resolves({ rows: [testData.carShows[2]] });
       const data = await service.get(3);
       expect(data).to.deep.equal({
         id: 3,
@@ -442,17 +426,14 @@ describe('service: car-classes', () => {
       await service.getCurrent();
       expect(client.query.calledOnce).to.be.true;
       expect(
-        client.query.calledWith(
-          'select * from car_shows where year = $1',
-          [2016]
-        )
+        client.query.calledWith('select * from car_shows where year = $1', [
+          2016
+        ])
       ).to.be.true;
     });
 
     it('querys the classes if the car show query returns a show', async () => {
-      client.query
-        .onCall(0)
-        .returns(Promise.resolve({ rows: [testData.carShows[1]] }));
+      client.query.onCall(0).resolves({ rows: [testData.carShows[1]] });
       await service.getCurrent();
       expect(client.query.calledTwice).to.be.true;
       expect(
@@ -469,14 +450,10 @@ describe('service: car-classes', () => {
     });
 
     it('returns the combined data', async () => {
-      client.query
-        .onCall(0)
-        .returns(Promise.resolve({ rows: [testData.carShows[1]] }));
-      client.query.onCall(1).returns(
-        Promise.resolve({
-          rows: testData.carShowClasses.filter(cls => cls.car_show_rid === 2)
-        })
-      );
+      client.query.onCall(0).resolves({ rows: [testData.carShows[1]] });
+      client.query.onCall(1).resolves({
+        rows: testData.carShowClasses.filter(cls => cls.car_show_rid === 2)
+      });
       const show = await service.getCurrent();
       expect(show).to.deep.equal({
         id: 2,
@@ -606,10 +583,7 @@ describe('service: car-classes', () => {
       it('queries the show and classes for the show', async () => {
         await service.save(testCarShow);
         expect(
-          client.query.calledWith(
-            'select * from car_shows where id = $1',
-            [2]
-          )
+          client.query.calledWith('select * from car_shows where id = $1', [2])
         ).to.be.true;
         expect(
           client.query.calledWith(
@@ -619,19 +593,11 @@ describe('service: car-classes', () => {
         ).to.be.true;
       });
 
-      it('returns the show as queried', async() => {
-        client.query
-          .onCall(5)
-          .returns(Promise.resolve({ rows: [testData.carShows[1]] }));
-        client.query
-          .onCall(6)
-          .returns(
-            Promise.resolve({
-              rows: testData.carShowClasses.filter(
-                cls => cls.car_show_rid === 2
-              )
-            })
-          );
+      it('returns the show as queried', async () => {
+        client.query.onCall(5).resolves({ rows: [testData.carShows[1]] });
+        client.query.onCall(6).resolves({
+          rows: testData.carShowClasses.filter(cls => cls.car_show_rid === 2)
+        });
         const show = await service.save(testCarShow);
         expect(show).to.deep.equal({
           id: 2,
@@ -700,9 +666,7 @@ describe('service: car-classes', () => {
           ]
         };
 
-        client.query
-          .onCall(0)
-          .returns(Promise.resolve({ rows: [{ id: 42 }] }));
+        client.query.onCall(0).resolves({ rows: [{ id: 42 }] });
       });
 
       it('connects to the pool', () => {
@@ -745,10 +709,7 @@ describe('service: car-classes', () => {
       it('queries the show and classes for the dhow', async () => {
         await service.save(testCarShow);
         expect(
-          client.query.calledWith(
-            'select * from car_shows where id = $1',
-            [42]
-          )
+          client.query.calledWith('select * from car_shows where id = $1', [42])
         ).to.be.true;
         expect(
           client.query.calledWith(
@@ -759,18 +720,10 @@ describe('service: car-classes', () => {
       });
 
       it('returns the show as queried', async () => {
-        client.query
-          .onCall(4)
-          .returns(Promise.resolve({ rows: [testData.carShows[1]] }));
-        client.query
-          .onCall(5)
-          .returns(
-            Promise.resolve({
-              rows: testData.carShowClasses.filter(
-                cls => cls.car_show_rid === 2
-              )
-            })
-          );
+        client.query.onCall(4).resolves({ rows: [testData.carShows[1]] });
+        client.query.onCall(5).resolves({
+          rows: testData.carShowClasses.filter(cls => cls.car_show_rid === 2)
+        });
         const show = await service.save(testCarShow);
         expect(show).to.deep.equal({
           id: 2,

--- a/test/services/encryption.spec.js
+++ b/test/services/encryption.spec.js
@@ -1,15 +1,13 @@
 'use strict';
 
+const crypto = require('crypto');
 const expect = require('chai').expect;
-const proxyquire = require('proxyquire');
+const service = require('../../src/services/encryption');
 const sinon = require('sinon');
 
 describe('service: encryption', () => {
   let mockBuffer;
-  let mockCrypto;
   let mockHmac;
-
-  let service;
 
   beforeEach(() => {
     mockBuffer = {};
@@ -21,17 +19,14 @@ describe('service: encryption', () => {
     });
     mockHmac.update.returns(mockHmac);
 
-    mockCrypto = sinon.stub({
-      randomBytes: function() {},
-      createHmac: function() {}
-    });
-    mockCrypto.randomBytes.returns(mockBuffer);
-    mockCrypto.createHmac.returns(mockHmac);
-
-    service = proxyquire('../../src/services/encryption', {
-      crypto: mockCrypto
-    });
+    sinon.stub(crypto, 'randomBytes').returns(mockBuffer);
+    sinon.stub(crypto, 'createHmac').returns(mockHmac);
   });
+
+  afterEach(() => {
+    crypto.randomBytes.restore();
+    crypto.createHmac.restore();
+  })
 
   it('exists', () => {
     expect(service).to.exist;
@@ -40,8 +35,8 @@ describe('service: encryption', () => {
   describe('salt', () => {
     it('gets 128 random bytes', () => {
       service.salt();
-      expect(mockCrypto.randomBytes.calledOnce).to.be.true;
-      expect(mockCrypto.randomBytes.calledWith(128)).to.be.true;
+      expect(crypto.randomBytes.calledOnce).to.be.true;
+      expect(crypto.randomBytes.calledWith(128)).to.be.true;
     });
 
     it('converts the byte buffer to a string', () => {
@@ -59,8 +54,8 @@ describe('service: encryption', () => {
   describe('hash', () => {
     it('creates a sha1 hmac', () => {
       service.hash('NaCl', 'shhh secret');
-      expect(mockCrypto.createHmac.calledOnce).to.be.true;
-      expect(mockCrypto.createHmac.calledWith('sha1', 'NaCl')).to.be.true;
+      expect(crypto.createHmac.calledOnce).to.be.true;
+      expect(crypto.createHmac.calledWith('sha1', 'NaCl')).to.be.true;
     });
 
     it('updates the hmac with the password', () => {

--- a/test/services/encryption.spec.js
+++ b/test/services/encryption.spec.js
@@ -26,7 +26,7 @@ describe('service: encryption', () => {
   afterEach(() => {
     crypto.randomBytes.restore();
     crypto.createHmac.restore();
-  })
+  });
 
   it('exists', () => {
     expect(service).to.exist;

--- a/test/services/encryption.spec.js
+++ b/test/services/encryption.spec.js
@@ -9,7 +9,7 @@ describe('service: encryption', () => {
   let mockCrypto;
   let mockHmac;
 
-  let Service;
+  let service;
 
   beforeEach(() => {
     mockBuffer = {};
@@ -28,33 +28,29 @@ describe('service: encryption', () => {
     mockCrypto.randomBytes.returns(mockBuffer);
     mockCrypto.createHmac.returns(mockHmac);
 
-    Service = proxyquire('../../src/services/encryption', {
+    service = proxyquire('../../src/services/encryption', {
       crypto: mockCrypto
     });
   });
 
   it('exists', () => {
-    const service = new Service();
     expect(service).to.exist;
   });
 
   describe('salt', () => {
     it('gets 128 random bytes', () => {
-      const service = new Service();
       service.salt();
       expect(mockCrypto.randomBytes.calledOnce).to.be.true;
       expect(mockCrypto.randomBytes.calledWith(128)).to.be.true;
     });
 
     it('converts the byte buffer to a string', () => {
-      const service = new Service();
       service.salt();
       expect(mockBuffer.toString.calledOnce).to.be.true;
       expect(mockBuffer.toString.calledWith('base64')).to.be.true;
     });
 
     it('returns the salt string', () => {
-      const service = new Service();
       mockBuffer.toString.returns('NaCl');
       expect(service.salt()).to.equal('NaCl');
     });
@@ -62,14 +58,12 @@ describe('service: encryption', () => {
 
   describe('hash', () => {
     it('creates a sha1 hmac', () => {
-      const service = new Service();
       service.hash('NaCl', 'shhh secret');
       expect(mockCrypto.createHmac.calledOnce).to.be.true;
       expect(mockCrypto.createHmac.calledWith('sha1', 'NaCl')).to.be.true;
     });
 
     it('updates the hmac with the password', () => {
-      const service = new Service();
       service.hash('NaCl', 'shhh secret');
       expect(mockHmac.update.calledOnce).to.be.true;
       expect(mockHmac.update.calledWith('shhh secret')).to.be.true;
@@ -77,7 +71,6 @@ describe('service: encryption', () => {
 
     it('returns a hex digest of the hmac', () => {
       mockHmac.digest.returns('8859AADEF095');
-      const service = new Service();
       const hash = service.hash('NaCl', 'shhh secret');
       expect(mockHmac.digest.calledOnce).to.be.true;
       expect(mockHmac.digest.calledWith('hex')).to.be.true;

--- a/test/services/password.spec.js
+++ b/test/services/password.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const expect = require('chai').expect;
-const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
 const MockClient = require('../mocks/mock-client');

--- a/test/services/password.spec.js
+++ b/test/services/password.spec.js
@@ -4,31 +4,26 @@ const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
-const MockPool = require('../mocks/mock-pool');
+const MockClient = require('../mocks/mock-client');
+const pool = require('../../src/config/database');
 
-let Password;
-
-let mockHash = sinon.stub();
-let mockSalt = sinon.stub();
-
-class MockEncryption {
-  constructor() {
-    this.salt = mockSalt;
-    this.hash = mockHash;
-  }
-}
+const encryption = require('../../src/services/encryption');
+const password = require('../../src/services/password');
 
 describe('service: password', () => {
-  let password;
-  let pool;
+  let client;
   beforeEach(() => {
-    mockHash.reset();
-    mockSalt.reset();
-    pool = new MockPool();
-    Password = proxyquire('../../src/services/password', {
-      './encryption': MockEncryption
-    });
-    password = new Password(pool);
+    sinon.stub(encryption, 'hash');
+    sinon.stub(encryption, 'salt');
+    client = new MockClient();
+    sinon.stub(pool, 'connect');
+    pool.connect.returns(Promise.resolve(client));
+  });
+
+  afterEach(() => {
+    encryption.hash.restore();
+    encryption.salt.restore();
+    pool.connect.restore();
   });
 
   it('exists', () => {
@@ -37,8 +32,8 @@ describe('service: password', () => {
 
   describe('initialize', () => {
     beforeEach(() => {
-      sinon.stub(pool.test_client, 'query');
-      pool.test_client.query.returns(Promise.resolve({ rows: [] }));
+      sinon.stub(client, 'query');
+      client.query.returns(Promise.resolve({ rows: [] }));
     });
 
     it('rejects if no user ID is given', async () => {
@@ -60,13 +55,12 @@ describe('service: password', () => {
     });
 
     it('connects to the pool', async () => {
-      sinon.spy(pool, 'connect');
       await password.initialize(42, 'shhhhhIam$ecret');
       expect(pool.connect.calledOnce).to.be.true;
     });
 
     it('rejects if a password row exists for the user', async () => {
-      pool.test_client.query.returns(
+      client.query.returns(
         Promise.resolve({
           rows: [
             {
@@ -86,26 +80,27 @@ describe('service: password', () => {
     });
 
     it('salts and encrypts the password', async () => {
-      mockSalt.returns('ABD349968NACL456');
+      encryption.salt.returns('ABD349968NACL456');
       await password.initialize(42, 'IamPassw0rd');
-      expect(mockSalt.calledOnce).to.be.true;
-      expect(mockHash.calledOnce).to.be.true;
-      expect(mockHash.calledWith('ABD349968NACL456', 'IamPassw0rd')).to.be.true;
+      expect(encryption.salt.calledOnce).to.be.true;
+      expect(encryption.hash.calledOnce).to.be.true;
+      expect(encryption.hash.calledWith('ABD349968NACL456', 'IamPassw0rd')).to
+        .be.true;
     });
 
     it('inserts the salted encrypted password', async () => {
-      mockSalt.returns('ABD349968NACL456');
-      mockHash
+      encryption.salt.returns('ABD349968NACL456');
+      encryption.hash
         .withArgs('ABD349968NACL456', 'IamPassw0rd')
         .returns('19934009599234095');
       await password.initialize(42, 'IamPassw0rd');
-      expect(pool.test_client.query.calledTwice).to.be.true;
+      expect(client.query.calledTwice).to.be.true;
       expect(
         /insert into user_credentials.*user_rid, password, salt/.test(
-          pool.test_client.query.args[1][0]
+          client.query.args[1][0]
         )
       ).to.be.true;
-      expect(pool.test_client.query.args[1][1]).to.deep.equal([
+      expect(client.query.args[1][1]).to.deep.equal([
         42,
         '19934009599234095',
         'ABD349968NACL456'
@@ -113,21 +108,23 @@ describe('service: password', () => {
     });
 
     it('releases the client', async () => {
-      sinon.spy(pool.test_client, 'release');
+      sinon.spy(client, 'release');
       await password.initialize(73, 'coop3r');
-      expect(pool.test_client.release.calledOnce).to.be.true;
+      expect(client.release.calledOnce).to.be.true;
     });
   });
 
   describe('change', () => {
     beforeEach(() => {
-      sinon.stub(pool.test_client, 'query');
-      pool.test_client.query.returns(
+      sinon.stub(client, 'query');
+      client.query.returns(
         Promise.resolve({
           rows: [{ id: 42, salt: '39949AAC43', password: 'ABBA1357CDDF' }]
         })
       );
-      mockHash.withArgs('39949AAC43', 'IamPassw0rd').returns('ABBA1357CDDF');
+      encryption.hash
+        .withArgs('39949AAC43', 'IamPassw0rd')
+        .returns('ABBA1357CDDF');
     });
 
     it('thows an error if no user ID is given', async () => {
@@ -149,13 +146,14 @@ describe('service: password', () => {
     });
 
     it('connects to the pool', async () => {
-      sinon.spy(pool, 'connect');
       await password.change(42, 'shhhhhIam$ecret', 'IamPassw0rd');
       expect(pool.connect.calledOnce).to.be.true;
     });
 
     it('throws an error if the current password is not valid', async () => {
-      mockHash.withArgs('39949AAC43', 'IamPassw0rd').returns('188492985AB34');
+      encryption.hash
+        .withArgs('39949AAC43', 'IamPassw0rd')
+        .returns('188492985AB34');
       try {
         await password.change(73, 'newpassword', 'IamPassw0rd');
         expect.fail(undefined, undefined, 'should have rejected');
@@ -165,27 +163,24 @@ describe('service: password', () => {
     });
 
     it('salts and encrypts the password', async () => {
-      mockSalt.returns('3848859ADNACL456');
+      encryption.salt.returns('3848859ADNACL456');
       await password.change(42, 'shhhhhIam$ecret', 'IamPassw0rd');
-      expect(mockSalt.calledOnce).to.be.true;
-      expect(mockHash.calledTwice).to.be.true; // first time is current password check
-      expect(mockHash.calledWith('3848859ADNACL456', 'shhhhhIam$ecret')).to.be
-        .true;
+      expect(encryption.salt.calledOnce).to.be.true;
+      expect(encryption.hash.calledTwice).to.be.true; // first time is current password check
+      expect(encryption.hash.calledWith('3848859ADNACL456', 'shhhhhIam$ecret'))
+        .to.be.true;
     });
 
     it('updates to the salted encrypted password', async () => {
-      mockSalt.returns('3848859ADNACL456');
-      mockHash
+      encryption.salt.returns('3848859ADNACL456');
+      encryption.hash
         .withArgs('3848859ADNACL456', 'shhhhhIam$ecret')
         .returns('AFED9948577FFED');
       await password.change(42, 'shhhhhIam$ecret', 'IamPassw0rd');
-      expect(pool.test_client.query.calledTwice).to.be.true;
-      expect(
-        /on conflict \(user_rid\) do update/.test(
-          pool.test_client.query.args[1][0]
-        )
-      ).to.be.true;
-      expect(pool.test_client.query.args[1][1]).to.deep.equal([
+      expect(client.query.calledTwice).to.be.true;
+      expect(/on conflict \(user_rid\) do update/.test(client.query.args[1][0]))
+        .to.be.true;
+      expect(client.query.args[1][1]).to.deep.equal([
         42,
         'AFED9948577FFED',
         '3848859ADNACL456'
@@ -193,29 +188,28 @@ describe('service: password', () => {
     });
 
     it('releases the client', async () => {
-      sinon.spy(pool.test_client, 'release');
+      sinon.spy(client, 'release');
       await password.change(73, 'coop3r', 'IamPassw0rd');
-      expect(pool.test_client.release.calledOnce).to.be.true;
+      expect(client.release.calledOnce).to.be.true;
     });
   });
 
   describe('matches', () => {
     beforeEach(() => {
-      mockHash.withArgs('39949AAC43', 'IamPassw0rd').returns('F00BA4');
+      encryption.hash.withArgs('39949AAC43', 'IamPassw0rd').returns('F00BA4');
     });
 
     it('connects to the pool', () => {
-      sinon.spy(pool, 'connect');
       password.matches(42, 'shhhhhIam$ecret');
       expect(pool.connect.calledOnce).to.be.true;
     });
 
     it('queries the user credentials', async () => {
-      sinon.spy(pool.test_client, 'query');
+      sinon.spy(client, 'query');
       await password.matches(42, 'IamPassw0rd');
-      expect(pool.test_client.query.calledOnce).to.be.true;
+      expect(client.query.calledOnce).to.be.true;
       expect(
-        pool.test_client.query.calledWith(
+        client.query.calledWith(
           'select * from user_credentials where user_rid = $1',
           [42]
         )
@@ -223,15 +217,15 @@ describe('service: password', () => {
     });
 
     it('resolves false if the user has no credentials record', async () => {
-      sinon.stub(pool.test_client, 'query');
-      pool.test_client.query.returns(Promise.resolve({ rows: [] }));
+      sinon.stub(client, 'query');
+      client.query.returns(Promise.resolve({ rows: [] }));
       const match = await password.matches(42, 'IamPassw0rd');
       expect(match).to.be.false;
     });
 
     it('resolves false if the password hashes do not match', async () => {
-      sinon.stub(pool.test_client, 'query');
-      pool.test_client.query.returns(
+      sinon.stub(client, 'query');
+      client.query.returns(
         Promise.resolve({
           rows: [{ id: 42, salt: '39949AAC43', password: 'ABBA1357CDDF' }]
         })
@@ -241,8 +235,8 @@ describe('service: password', () => {
     });
 
     it('resolves true if the password hashes do match', async () => {
-      sinon.stub(pool.test_client, 'query');
-      pool.test_client.query.returns(
+      sinon.stub(client, 'query');
+      client.query.returns(
         Promise.resolve({
           rows: [{ id: 42, salt: '39949AAC43', password: 'F00BA4' }]
         })
@@ -252,9 +246,9 @@ describe('service: password', () => {
     });
 
     it('releases the client', async () => {
-      sinon.spy(pool.test_client, 'release');
+      sinon.spy(client, 'release');
       await password.matches(73, 'coop3r');
-      expect(pool.test_client.release.calledOnce).to.be.true;
+      expect(client.release.calledOnce).to.be.true;
     });
   });
 });

--- a/test/services/password.spec.js
+++ b/test/services/password.spec.js
@@ -17,7 +17,7 @@ describe('service: password', () => {
     sinon.stub(encryption, 'salt');
     client = new MockClient();
     sinon.stub(pool, 'connect');
-    pool.connect.returns(Promise.resolve(client));
+    pool.connect.resolves(client);
   });
 
   afterEach(() => {
@@ -33,7 +33,7 @@ describe('service: password', () => {
   describe('initialize', () => {
     beforeEach(() => {
       sinon.stub(client, 'query');
-      client.query.returns(Promise.resolve({ rows: [] }));
+      client.query.resolves({ rows: [] });
     });
 
     it('rejects if no user ID is given', async () => {
@@ -218,7 +218,7 @@ describe('service: password', () => {
 
     it('resolves false if the user has no credentials record', async () => {
       sinon.stub(client, 'query');
-      client.query.returns(Promise.resolve({ rows: [] }));
+      client.query.resolves({ rows: [] });
       const match = await password.matches(42, 'IamPassw0rd');
       expect(match).to.be.false;
     });

--- a/test/services/users.spec.js
+++ b/test/services/users.spec.js
@@ -1,33 +1,21 @@
 'use strict';
 
 const expect = require('chai').expect;
-const MockPool = require('../mocks/mock-pool');
-const proxyquire = require('proxyquire');
+const pool = require('../../src/config/database');
+const MockClient = require('../mocks/mock-client');
 const sinon = require('sinon');
 
-let passwordCalls;
-class MockPasswordService {
-  constructor() {
-    passwordCalls = new Map();
-  }
-
-  initialize(id, password) {
-    passwordCalls.set('method', 'initialize');
-    passwordCalls.set('id', id);
-    passwordCalls.set('password', password);
-  }
-}
-
-const Service = proxyquire('../../src/services/users', {
-  './password': MockPasswordService
-});
+const password = require('../../src/services/password');
+const service = require('../../src/services/users');
 
 describe('service: users', () => {
-  let pool;
+  let client;
   let testData;
 
   beforeEach(() => {
-    pool = new MockPool();
+    client = new MockClient();
+    sinon.stub(pool, 'connect');
+    pool.connect.returns(Promise.resolve(client));
     testData = [
       {
         id: 1,
@@ -44,77 +32,67 @@ describe('service: users', () => {
     ];
   });
 
+  afterEach(() => {
+    pool.connect.restore();
+  });
+
   describe('getAll', () => {
-    let service;
-
-    beforeEach(() => {
-      service = new Service(pool);
-    });
-
     it('connects to the pool', () => {
-      sinon.spy(pool, 'connect');
       service.getAll();
       expect(pool.connect.calledOnce).to.be.true;
     });
 
     it('queries the users', async () => {
-      sinon.spy(pool.test_client, 'query');
+      sinon.spy(client, 'query');
       await service.getAll();
-      expect(pool.test_client.query.calledOnce).to.be.true;
-      const sql = pool.test_client.query.args[0][0];
+      expect(client.query.calledOnce).to.be.true;
+      const sql = client.query.args[0][0];
       expect(/select .* from users/.test(sql)).to.be.true;
     });
 
     it('resolves the data', async () => {
-      sinon.stub(pool.test_client, 'query');
-      pool.test_client.query.returns(Promise.resolve({ rows: testData }));
+      sinon.stub(client, 'query');
+      client.query.returns(Promise.resolve({ rows: testData }));
       const data = await service.getAll();
       expect(data).to.deep.equal(testData);
     });
 
     it('releases the client', async () => {
-      sinon.spy(pool.test_client, 'release');
+      sinon.spy(client, 'release');
       await service.getAll();
-      expect(pool.test_client.release.calledOnce).to.be.true;
+      expect(client.release.calledOnce).to.be.true;
     });
   });
 
   describe('get', () => {
-    let service;
-
-    beforeEach(() => {
-      service = new Service(pool);
-    });
-
     it('connects to the pool', () => {
-      sinon.spy(pool, 'connect');
       service.get(42);
       expect(pool.connect.calledOnce).to.be.true;
     });
 
     it('queries the users for the user with the given ID', async () => {
-      sinon.spy(pool.test_client, 'query');
+      sinon.spy(client, 'query');
       await service.get(42);
-      expect(pool.test_client.query.calledOnce).to.be.true;
-      const args = pool.test_client.query.args[0];
+      expect(client.query.calledOnce).to.be.true;
+      const args = client.query.args[0];
       expect(/select .* from users where id = \$1/.test(args[0])).to.be.true;
       expect(args[1]).to.deep.equal([42]);
     });
 
     it('queries the users for the user with the given ID string', async () => {
-      sinon.spy(pool.test_client, 'query');
+      sinon.spy(client, 'query');
       await service.get('42');
-      expect(pool.test_client.query.calledOnce).to.be.true;
-      const args = pool.test_client.query.args[0];
+      expect(client.query.calledOnce).to.be.true;
+      const args = client.query.args[0];
       expect(/select .* from users where id = \$1/.test(args[0])).to.be.true;
       expect(args[1]).to.deep.equal(['42']);
     });
 
     it('queries the users by email if the passed id has an "@" sign', async () => {
-      sinon.spy(pool.test_client, 'query');
+      sinon.spy(client, 'query');
       await service.get('42@1138.73');
-      expect(pool.test_client.query.calledOnce).to.be.true;
-      const args = pool.test_client.query.args[0];
+      expect(client.query.calledOnce).to.be.true;
+      const args = client.query.args[0];
       expect(
         /select .* from users where upper\(email\) = upper\(\$1\)/.test(args[0])
       ).to.be.true;
@@ -122,8 +100,8 @@ describe('service: users', () => {
     });
 
     it('resolves the data', async () => {
-      sinon.stub(pool.test_client, 'query');
-      pool.test_client.query.returns(
+      sinon.stub(client, 'query');
+      client.query.returns(
         Promise.resolve({
           rows: [
             {
@@ -146,28 +124,21 @@ describe('service: users', () => {
     });
 
     it('resolves undefined if not found', async () => {
-      sinon.stub(pool.test_client, 'query');
-      pool.test_client.query.returns(Promise.resolve({ rows: [] }));
+      sinon.stub(client, 'query');
+      client.query.returns(Promise.resolve({ rows: [] }));
       const data = await service.get(42);
       expect(data).to.be.undefined;
     });
 
     it('releases the client', async () => {
-      sinon.spy(pool.test_client, 'release');
+      sinon.spy(client, 'release');
       await service.get(42);
-      expect(pool.test_client.release.calledOnce).to.be.true;
+      expect(client.release.calledOnce).to.be.true;
     });
   });
 
   describe('save', () => {
-    let service;
-
-    beforeEach(() => {
-      service = new Service(pool);
-    });
-
     it('connects to the pool', async () => {
-      sinon.spy(pool, 'connect');
       await service.save({
         firstName: 'Tess',
         lastName: 'McTesterson'
@@ -177,32 +148,39 @@ describe('service: users', () => {
 
     describe('a user with an ID', () => {
       it('updates the existing user', async () => {
-        sinon.spy(pool.test_client, 'query');
+        sinon.spy(client, 'query');
         await service.save({
           id: 4273,
           firstName: 'Tess',
           lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
-        expect(pool.test_client.query.calledOnce).to.be.true;
-        const sql = pool.test_client.query.args[0][0];
-        expect(/^update users.*where id = \$1 returning id, first_name as "firstName",/.test(sql)).to.be
-          .true;
+        expect(client.query.calledOnce).to.be.true;
+        const sql = client.query.args[0][0];
+        expect(
+          /^update users.*where id = \$1 returning id, first_name as "firstName",/.test(
+            sql
+          )
+        ).to.be.true;
       });
 
       it('does not touch the password', async () => {
+        sinon.spy(password, 'change');
+        sinon.spy(password, 'initialize');
         await service.save({
           id: 4273,
           firstName: 'Tess',
           lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
-        expect(passwordCalls.get('method')).to.be.undefined;
+        expect(password.change.called).to.be.false;
+        password.change.restore();
+        password.initialize.restore();
       });
 
       it('resolves the updated user', async () => {
-        sinon.stub(pool.test_client, 'query');
-        pool.test_client.query.returns(
+        sinon.stub(client, 'query');
+        client.query.returns(
           Promise.resolve({
             rows: [
               {
@@ -229,8 +207,8 @@ describe('service: users', () => {
       });
 
       it('resolves empty if there was no user to update', async () => {
-        sinon.stub(pool.test_client, 'query');
-        pool.test_client.query.returns(Promise.resolve({ rows: [] }));
+        sinon.stub(client, 'query');
+        client.query.returns(Promise.resolve({ rows: [] }));
         const user = await service.save({
           id: 4273,
           firstName: 'Tess',
@@ -242,21 +220,33 @@ describe('service: users', () => {
     });
 
     describe('a user without an ID', () => {
+      beforeEach(() => {
+        sinon.stub(password, 'initialize');
+      });
+
+      afterEach(() => {
+        password.initialize.restore();
+      });
+
       it('creates a new user', async () => {
-        sinon.spy(pool.test_client, 'query');
+        sinon.spy(client, 'query');
         await service.save({
           firstName: 'Tess',
           lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
-        expect(pool.test_client.query.calledOnce).to.be.true;
-        const sql = pool.test_client.query.args[0][0];
-        expect(/^insert into users.*returning id, first_name as "firstName",/.test(sql)).to.be.true;
+        expect(client.query.calledOnce).to.be.true;
+        const sql = client.query.args[0][0];
+        expect(
+          /^insert into users.*returning id, first_name as "firstName",/.test(
+            sql
+          )
+        ).to.be.true;
       });
 
       it('creates an initial password', async () => {
-        sinon.stub(pool.test_client, 'query');
-        pool.test_client.query.returns(
+        sinon.stub(client, 'query');
+        client.query.returns(
           Promise.resolve({
             rows: [
               {
@@ -274,14 +264,13 @@ describe('service: users', () => {
           email: 'tess@test.ly',
           password: 'I am a freak'
         });
-        expect(passwordCalls.get('method')).to.equal('initialize');
-        expect(passwordCalls.get('id')).to.equal(1138);
-        expect(passwordCalls.get('password')).to.equal('I am a freak');
+        expect(password.initialize.calledOnce).to.be.true;
+        expect(password.initialize.calledWith(1138, 'I am a freak')).to.be.true;
       });
 
       it('defaults to password if no password is given', async () => {
-        sinon.stub(pool.test_client, 'query');
-        pool.test_client.query.returns(
+        sinon.stub(client, 'query');
+        client.query.returns(
           Promise.resolve({
             rows: [
               {
@@ -298,14 +287,12 @@ describe('service: users', () => {
           lastName: 'McTesterson',
           email: 'tess@test.ly'
         });
-        expect(passwordCalls.get('method')).to.equal('initialize');
-        expect(passwordCalls.get('id')).to.equal(1138);
-        expect(passwordCalls.get('password')).to.equal('password');
+        expect(password.initialize.calledWith(1138, 'password')).to.be.true;
       });
 
       it('resolves the inserted user', async () => {
-        sinon.stub(pool.test_client, 'query');
-        pool.test_client.query.returns(
+        sinon.stub(client, 'query');
+        client.query.returns(
           Promise.resolve({
             rows: [
               {
@@ -332,12 +319,12 @@ describe('service: users', () => {
     });
 
     it('releases the client', async () => {
-      sinon.spy(pool.test_client, 'release');
+      sinon.spy(client, 'release');
       await service.save({
         firstName: 'Tess',
         lastName: 'McTesterson'
       });
-      expect(pool.test_client.release.calledOnce).to.be.true;
+      expect(client.release.calledOnce).to.be.true;
     });
   });
 });

--- a/test/services/users.spec.js
+++ b/test/services/users.spec.js
@@ -15,7 +15,7 @@ describe('service: users', () => {
   beforeEach(() => {
     client = new MockClient();
     sinon.stub(pool, 'connect');
-    pool.connect.returns(Promise.resolve(client));
+    pool.connect.resolves(client);
     testData = [
       {
         id: 1,
@@ -52,7 +52,7 @@ describe('service: users', () => {
 
     it('resolves the data', async () => {
       sinon.stub(client, 'query');
-      client.query.returns(Promise.resolve({ rows: testData }));
+      client.query.resolves({ rows: testData });
       const data = await service.getAll();
       expect(data).to.deep.equal(testData);
     });
@@ -125,7 +125,7 @@ describe('service: users', () => {
 
     it('resolves undefined if not found', async () => {
       sinon.stub(client, 'query');
-      client.query.returns(Promise.resolve({ rows: [] }));
+      client.query.resolves({ rows: [] });
       const data = await service.get(42);
       expect(data).to.be.undefined;
     });
@@ -208,7 +208,7 @@ describe('service: users', () => {
 
       it('resolves empty if there was no user to update', async () => {
         sinon.stub(client, 'query');
-        client.query.returns(Promise.resolve({ rows: [] }));
+        client.query.resolves({ rows: [] });
         const user = await service.save({
           id: 4273,
           firstName: 'Tess',

--- a/test/services/votes.spec.js
+++ b/test/services/votes.spec.js
@@ -13,7 +13,7 @@ describe('service: votes', () => {
   beforeEach(() => {
     client = new MockClient();
     sinon.stub(database, 'connect');
-    database.connect.returns(Promise.resolve(client));
+    database.connect.resolves(client);
     testData = [
       {
         id: 1,
@@ -38,7 +38,7 @@ describe('service: votes', () => {
 
   afterEach(() => {
     database.connect.restore();
-  })
+  });
 
   describe('getAll', () => {
     it('connects to the pool', () => {
@@ -50,20 +50,21 @@ describe('service: votes', () => {
       sinon.spy(client, 'query');
       await service.getAll();
       expect(client.query.calledOnce).to.be.true;
-      expect(client.query.calledWith('select * from votes')).to.be
-        .true;
+      expect(client.query.calledWith('select * from votes')).to.be.true;
     });
 
     it('limits by year if given', async () => {
       sinon.spy(client, 'query');
       await service.getAll(2019);
       expect(client.query.calledOnce).to.be.true;
-      expect(client.query.calledWith('select * from votes where year = $1', [2019])).to.be.true;
+      expect(
+        client.query.calledWith('select * from votes where year = $1', [2019])
+      ).to.be.true;
     });
 
     it('returns the data', async () => {
       sinon.stub(client, 'query');
-      client.query.returns(Promise.resolve({ rows: testData }));
+      client.query.resolves({ rows: testData });
       const data = await service.getAll();
       expect(data).to.deep.equal(testData);
     });

--- a/test/services/votes.spec.js
+++ b/test/services/votes.spec.js
@@ -1,17 +1,19 @@
 'use strict';
 
 const expect = require('chai').expect;
-const MockPool = require('../mocks/mock-pool');
+const database = require('../../src/config/database');
+const MockClient = require('../mocks/mock-client');
 const sinon = require('sinon');
-const Service = require('../../src/services/votes');
+const service = require('../../src/services/votes');
 
 describe('service: votes', () => {
-  let pool;
-  let service;
+  let client;
   let testData;
 
   beforeEach(() => {
-    pool = new MockPool();
+    client = new MockClient();
+    sinon.stub(database, 'connect');
+    database.connect.returns(Promise.resolve(client));
     testData = [
       {
         id: 1,
@@ -32,71 +34,72 @@ describe('service: votes', () => {
         car_number: 73
       }
     ];
-    service = new Service(pool);
   });
+
+  afterEach(() => {
+    database.connect.restore();
+  })
 
   describe('getAll', () => {
     it('connects to the pool', () => {
-      sinon.spy(pool, 'connect');
       service.getAll();
-      expect(pool.connect.calledOnce).to.be.true;
+      expect(database.connect.calledOnce).to.be.true;
     });
 
     it('queries the votes', async () => {
-      sinon.spy(pool.test_client, 'query');
+      sinon.spy(client, 'query');
       await service.getAll();
-      expect(pool.test_client.query.calledOnce).to.be.true;
-      expect(pool.test_client.query.calledWith('select * from votes')).to.be
+      expect(client.query.calledOnce).to.be.true;
+      expect(client.query.calledWith('select * from votes')).to.be
         .true;
     });
 
     it('limits by year if given', async () => {
-      sinon.spy(pool.test_client, 'query');
+      sinon.spy(client, 'query');
       await service.getAll(2019);
-      expect(pool.test_client.query.calledOnce).to.be.true;
-      expect(pool.test_client.query.calledWith('select * from votes where year = $1', [2019])).to.be.true;
+      expect(client.query.calledOnce).to.be.true;
+      expect(client.query.calledWith('select * from votes where year = $1', [2019])).to.be.true;
     });
 
     it('returns the data', async () => {
-      sinon.stub(pool.test_client, 'query');
-      pool.test_client.query.returns(Promise.resolve({ rows: testData }));
+      sinon.stub(client, 'query');
+      client.query.returns(Promise.resolve({ rows: testData }));
       const data = await service.getAll();
       expect(data).to.deep.equal(testData);
     });
 
     it('releases the client', async () => {
-      sinon.spy(pool.test_client, 'release');
+      sinon.spy(client, 'release');
       await service.getAll();
-      expect(pool.test_client.release.calledOnce).to.be.true;
+      expect(client.release.calledOnce).to.be.true;
     });
   });
 
   // describe('get', () => {
   //   it('connects to the pool', () => {
-  //     sinon.spy(pool, 'connect');
   //     service.get(42);
   //     expect(pool.connect.calledOnce).to.be.true;
   //   });
 
   //   it('releases the client', async () => {
-  //     sinon.spy(pool.test_client, 'release');
+  //     sinon.spy(client, 'release');
   //     await service.get(42);
-  //     expect(pool.test_client.release.calledOnce).to.be.true;
+  //     expect(client.release.calledOnce).to.be.true;
   //   });
 
   //   it('queries the teas for the tea with the given ID', async () => {
-  //     sinon.spy(pool.test_client, 'query');
+  //     sinon.spy(client, 'query');
   //     await service.get(42);
-  //     expect(pool.test_client.query.calledOnce).to.be.true;
-  //     const args = pool.test_client.query.args[0];
+  //     expect(client.query.calledOnce).to.be.true;
+  //     const args = client.query.args[0];
   //     expect(/select .* from teas .* where teas\.id = \$1/.test(args[0])).to.be
   //       .true;
   //     expect(args[1]).to.deep.equal([42]);
   //   });
 
   //   it('resolves the data', async () => {
-  //     sinon.stub(pool.test_client, 'query');
-  //     pool.test_client.query.returns(
+  //     sinon.stub(client, 'query');
+  //     client.query.returns(
   //       Promise.resolve({
   //         rows: [
   //           {
@@ -122,14 +125,13 @@ describe('service: votes', () => {
 
   // describe('save', () => {
   //   it('connects to the pool', () => {
-  //     sinon.spy(pool, 'connect');
   //     service.save({});
   //     expect(pool.connect.calledOnce).to.be.true;
   //   });
 
   //   describe('with an ID', () => {
   //     it('updates the given tea', async () => {
-  //       sinon.spy(pool.test_client, 'query');
+  //       sinon.spy(client, 'query');
   //       await service.save({
   //         id: 42,
   //         name: 'Monkey Picked Oolong',
@@ -137,19 +139,19 @@ describe('service: votes', () => {
   //         teaCategoryName: 'Oolong',
   //         description: 'Good quality basic oolong tea'
   //       });
-  //       expect(pool.test_client.query.calledTwice).to.be.true;
-  //       let args = pool.test_client.query.args[0];
+  //       expect(client.query.calledTwice).to.be.true;
+  //       let args = client.query.args[0];
   //       expect(/update teas .*/.test(args[0])).to.be.true;
 
-  //       args = pool.test_client.query.args[1];
+  //       args = client.query.args[1];
   //       expect(/select .* from teas .* where teas\.id = \$1/.test(args[0])).to
   //         .be.true;
   //       expect(args[1]).to.deep.equal([42]);
   //     });
 
   //     it('returns the updated tea', async () => {
-  //       sinon.stub(pool.test_client, 'query');
-  //       pool.test_client.query.returns(
+  //       sinon.stub(client, 'query');
+  //       client.query.returns(
   //         Promise.resolve({
   //           rows: [
   //             {
@@ -181,13 +183,13 @@ describe('service: votes', () => {
 
   //   describe('without an ID', () => {
   //     beforeEach(() => {
-  //       sinon.stub(pool.test_client, 'query');
-  //       pool.test_client.query.onCall(0).returns(
+  //       sinon.stub(client, 'query');
+  //       client.query.onCall(0).returns(
   //         Promise.resolve({
   //           rows: [{ id: 1138 }]
   //         })
   //       );
-  //       pool.test_client.query.onCall(1).returns(
+  //       client.query.onCall(1).returns(
   //         Promise.resolve({
   //           rows: [
   //             {
@@ -209,11 +211,11 @@ describe('service: votes', () => {
   //         teaCategoryName: 'Oolong',
   //         description: 'Good quality basic oolong tea'
   //       });
-  //       expect(pool.test_client.query.calledTwice).to.be.true;
-  //       let args = pool.test_client.query.args[0];
+  //       expect(client.query.calledTwice).to.be.true;
+  //       let args = client.query.args[0];
   //       expect(/insert into teas .* returning id/.test(args[0])).to.be.true;
 
-  //       args = pool.test_client.query.args[1];
+  //       args = client.query.args[1];
   //       expect(/select .* from teas .* where teas\.id = \$1/.test(args[0])).to
   //         .be.true;
   //       expect(args[1]).to.deep.equal([1138]);
@@ -237,38 +239,37 @@ describe('service: votes', () => {
   //   });
 
   //   it('releases the client', async () => {
-  //     sinon.spy(pool.test_client, 'release');
+  //     sinon.spy(client, 'release');
   //     await service.save({});
-  //     expect(pool.test_client.release.calledOnce).to.be.true;
+  //     expect(client.release.calledOnce).to.be.true;
   //   });
   // });
 
   // describe('delete', () => {
   //   it('connects to the pool', () => {
-  //     sinon.spy(pool, 'connect');
   //     service.delete(42);
   //     expect(pool.connect.calledOnce).to.be.true;
   //   });
 
   //   it('deletes the tea with the given ID', async () => {
-  //     sinon.spy(pool.test_client, 'query');
+  //     sinon.spy(client, 'query');
   //     await service.delete(42);
-  //     expect(pool.test_client.query.calledTwice).to.be.true;
+  //     expect(client.query.calledTwice).to.be.true;
 
-  //     let args = pool.test_client.query.args[0];
+  //     let args = client.query.args[0];
   //     expect(/delete from tea_purchase_links where tea_rid = \$1/.test(args[0]))
   //       .to.be.true;
   //     expect(args[1]).to.deep.equal([42]);
 
-  //     args = pool.test_client.query.args[1];
+  //     args = client.query.args[1];
   //     expect(/delete from teas where id = \$1/.test(args[0])).to.be.true;
   //     expect(args[1]).to.deep.equal([42]);
   //   });
 
   //   it('releases the client', async () => {
-  //     sinon.spy(pool.test_client, 'release');
+  //     sinon.spy(client, 'release');
   //     await service.delete(42);
-  //     expect(pool.test_client.release.calledOnce).to.be.true;
+  //     expect(client.release.calledOnce).to.be.true;
   //   });
   // });
 });


### PR DESCRIPTION
Making the database return a singleton pool rather than a function that creates a pool  let's the module system handle everything. This makes things easier to mock.
